### PR TITLE
Feat: 어드민 페이지 API 연결, 페이지 2

### DIFF
--- a/src/api/admin.ts
+++ b/src/api/admin.ts
@@ -98,13 +98,16 @@ export const addInstitutions = async (
   membersCount: number,
 ) => {
   try {
-    const response = await axios.post(`/v1/institutions/admin`, null, {
-      params: { name, address, phone, postalCode, startDate, membersCount },
+    const response = await axios.post(`/v1/institutions/admin`, {
+      name,
+      address,
+      phone,
+      postalCode,
+      startDate,
+      membersCount,
     });
 
-    if (response.data.isSuccess) {
-      console.log("institution add complete");
-    }
+    return response.data.isSuccess;
   } catch (error) {
     console.error(error);
   }

--- a/src/api/admin.ts
+++ b/src/api/admin.ts
@@ -1,0 +1,111 @@
+import { DELIVERY_STATUS } from "@/constants/delivery-status";
+import axios from "@/lib/axios";
+import { useSuperAdminStore } from "@/stores/admin/useSuperAdminStroe";
+
+/* GET: 개인 플랜 소식지 정보 모두 갖고 오기 */
+export const getHomeArchives = async (year: number, month: number) => {
+  try {
+    const response = await axios.get(`/v1/master/admin/home/archives`, {
+      params: {
+        year,
+        month,
+      },
+    });
+    if (response.data.isSuccess) {
+      const { homeArchives } = response.data.result;
+      useSuperAdminStore.getState().setIndividuals(homeArchives);
+    }
+  } catch (error) {
+    console.error(error);
+    return [];
+  }
+};
+
+/* GET: 기관 플랜 소식지 정보 모두 갖고 오기 */
+export const getInstitutionArchives = async (year: number, month: number) => {
+  try {
+    const response = await axios.get(`/v1/master/admin/institutions`, {
+      params: {
+        year,
+        month,
+      },
+    });
+
+    if (response.data.isSuccess) {
+      useSuperAdminStore
+        .getState()
+        .setInstitutions(response.data.result.institutionInfoList);
+    }
+  } catch (error) {
+    console.error(error);
+    return [];
+  }
+};
+
+/* POST: 한 소식지 배송 상태 변경 */
+export const setArchiveDeliveryStatus = async (
+  archiveId: number,
+  deliveryStatus: keyof typeof DELIVERY_STATUS,
+) => {
+  try {
+    const response = await axios.post(
+      `/v1/master/admin/${archiveId}/home`,
+      null,
+      {
+        params: { deliveryStatus },
+      },
+    );
+
+    if (response.data.isSuccess) {
+      console.log("change delivery status");
+    }
+  } catch (error) {
+    console.error(error);
+  }
+};
+
+/* POST: 기관 플랜에 속한 모든 가족 배송 상태 변경 -> 작동 x */
+export const setInstitutionDeliveryStatus = async (
+  institutionId: number,
+  deliveryStatus: keyof typeof DELIVERY_STATUS,
+  year: number,
+  month: number,
+) => {
+  try {
+    const response = await axios.post(
+      `/v1/master/admin/${institutionId}/institution`,
+      null,
+      {
+        params: { deliveryStatus, year, month },
+      },
+    );
+
+    if (response.data.isSuccess) {
+      console.log("change delivery status");
+    }
+  } catch (error) {
+    console.error(error);
+  }
+};
+
+/* POST: 기관 생성 */
+export const addInstitutions = async (
+  name: string,
+  address: string,
+  phone: string,
+  postalCode: string,
+  startDate: string,
+  membersCount: number,
+) => {
+  try {
+    const response = await axios.post(`/v1/institutions/admin`, null, {
+      params: { name, address, phone, postalCode, startDate, membersCount },
+    });
+
+    if (response.data.isSuccess) {
+      console.log("institution add complete");
+    }
+  } catch (error) {
+    console.error(error);
+  }
+};

--- a/src/api/admin.ts
+++ b/src/api/admin.ts
@@ -72,13 +72,11 @@ export const setInstitutionDeliveryStatus = async (
   month: number,
 ) => {
   try {
-    const response = await axios.post(
-      `/v1/master/admin/${code}/institution`,
-      null,
-      {
-        params: { deliveryStatus, year, month },
-      },
-    );
+    const response = await axios.post(`/v1/master/admin/${code}/institution`, {
+      deliveryStatus,
+      year,
+      month,
+    });
 
     if (response.data.isSuccess) {
       console.log("change delivery status");

--- a/src/api/admin.ts
+++ b/src/api/admin.ts
@@ -64,16 +64,16 @@ export const setArchiveDeliveryStatus = async (
   }
 };
 
-/* POST: 기관 플랜에 속한 모든 가족 배송 상태 변경 -> 작동 x */
+/* POST: 기관 플랜에 속한 모든 가족 배송 상태 변경 */
 export const setInstitutionDeliveryStatus = async (
-  institutionId: number,
+  code: string,
   deliveryStatus: keyof typeof DELIVERY_STATUS,
   year: number,
   month: number,
 ) => {
   try {
     const response = await axios.post(
-      `/v1/master/admin/${institutionId}/institution`,
+      `/v1/master/admin/${code}/institution`,
       null,
       {
         params: { deliveryStatus, year, month },

--- a/src/app/(admin)/admin/_components/button/change-status.tsx
+++ b/src/app/(admin)/admin/_components/button/change-status.tsx
@@ -1,6 +1,14 @@
-const ChangeStatus = ({ selectedItemCount }: { selectedItemCount: number }) => {
+const ChangeStatus = ({
+  selectedItemCount,
+  onClick,
+}: {
+  selectedItemCount: number;
+  onClick: () => void;
+}) => {
   return (
-    <button className="button">{selectedItemCount}건 일괄 상태 변경</button>
+    <button className="button" onClick={onClick}>
+      {selectedItemCount}건 일괄 상태 변경
+    </button>
   );
 };
 

--- a/src/app/(admin)/admin/_components/button/checkbox.tsx
+++ b/src/app/(admin)/admin/_components/button/checkbox.tsx
@@ -8,16 +8,28 @@ import { CheckboxProps } from "./checkbox-props";
 const Checkbox = ({
   idValue,
   callback,
+  isChecked,
 }: {
   idValue: number;
   callback: CheckboxProps;
+  isChecked?: boolean;
 }) => {
-  const [checked, setChecked] = useState(false);
+  const [checked, setChecked] = useState<boolean>(false);
   const handleCheckboxClick = () => setChecked((prev) => !prev);
+  const [isInitialized, setIsInitialized] = useState(false);
 
   useEffect(() => {
-    callback(idValue, checked);
-  }, [checked]);
+    if (isChecked !== undefined) {
+      setChecked(isChecked);
+      setIsInitialized(true);
+    }
+  }, [isChecked]);
+
+  useEffect(() => {
+    if (isInitialized) {
+      callback(idValue, checked);
+    }
+  }, [checked, isInitialized]);
 
   return (
     <button type="button" onClick={handleCheckboxClick}>

--- a/src/app/(admin)/admin/_components/modal/modal.tsx
+++ b/src/app/(admin)/admin/_components/modal/modal.tsx
@@ -10,6 +10,7 @@ import { STATUS_CHANGE_ITEMS } from "../table/table-items";
 import ItemCount from "../table/item-count";
 import { IndividualsDto, InstitutionsDto } from "@/types/admin-dto";
 import { TableItem } from "../table/table-item";
+import { CheckboxProps } from "../button/checkbox-props";
 
 const Modal = ({
   idList,
@@ -20,7 +21,7 @@ const Modal = ({
   idList: number[];
   items: InstitutionsDto[] | IndividualsDto[];
   onClose: () => void;
-  handleCheckboxChange: (id: number, checked: boolean) => void;
+  handleCheckboxChange: CheckboxProps;
 }) => {
   const [selectedStatus, setStatus] = useState<
     keyof typeof DELIVERY_STATUS | null
@@ -46,8 +47,6 @@ const Modal = ({
       }
     })
     .filter((item) => item !== undefined);
-  console.log("targetList", targetList);
-  console.log("idList", idList);
 
   return createPortal(
     <div className="modal-bg top-0 left-0 flex h-full w-full items-center justify-center">
@@ -85,7 +84,7 @@ const Modal = ({
           TABLE_COLUMNS={STATUS_CHANGE_ITEMS}
           keyPrefix={"change-"}
         />
-        <section className="overflow-auto-hide-scroll h-[400px]">
+        <section className="overflow-auto-hide-scroll max-h-[400px]">
           {targetList.map((target, index) => (
             <TableItem
               key={"target" + index}
@@ -93,6 +92,7 @@ const Modal = ({
               index={index + 1}
               id={target.id}
               item={{ ...target, selectedStatus: selectedStatus }}
+              isChecked={idList.includes(target.id)}
               action={handleCheckboxChange}
             />
           ))}

--- a/src/app/(admin)/admin/_components/modal/modal.tsx
+++ b/src/app/(admin)/admin/_components/modal/modal.tsx
@@ -11,21 +11,31 @@ import ItemCount from "../table/item-count";
 import { IndividualsDto, InstitutionsDto } from "@/types/admin-dto";
 import { TableItem } from "../table/table-item";
 import { CheckboxProps } from "../button/checkbox-props";
+import {
+  setArchiveDeliveryStatus,
+  setInstitutionDeliveryStatus,
+} from "@/api/admin";
+import { useSuperAdminStore } from "@/stores/admin/useSuperAdminStroe";
 
 const Modal = ({
   idList,
   items,
   onClose,
   handleCheckboxChange,
+  resetCheckItem,
 }: {
   idList: number[];
   items: InstitutionsDto[] | IndividualsDto[];
   onClose: () => void;
   handleCheckboxChange: CheckboxProps;
+  resetCheckItem: () => void;
 }) => {
   const [selectedStatus, setStatus] = useState<
     keyof typeof DELIVERY_STATUS | null
   >(null);
+  const [processing, setProcessing] = useState(false);
+  const { pivotDate, setPivotDate } = useSuperAdminStore();
+
   const targetList = items
     .map((item) => {
       if ("institutionId" in item) {
@@ -47,6 +57,33 @@ const Modal = ({
       }
     })
     .filter((item) => item !== undefined);
+
+  const handleChangeStatus = async () => {
+    setProcessing(true);
+    if (selectedStatus === null) return;
+    const date = new Date(pivotDate);
+    const results = await Promise.allSettled(
+      targetList.map(({ code }) =>
+        typeof code === "string"
+          ? setInstitutionDeliveryStatus(
+              code,
+              selectedStatus,
+              date.getFullYear(),
+              date.getMonth(),
+            )
+          : setArchiveDeliveryStatus(code, selectedStatus),
+      ),
+    );
+
+    const failures = results.filter((item) => item.status === "rejected");
+
+    if (failures.length === 0) {
+      resetCheckItem();
+      onClose();
+      setPivotDate(date);
+    }
+    setProcessing(false);
+  };
 
   return createPortal(
     <div className="modal-bg top-0 left-0 flex h-full w-full items-center justify-center">
@@ -79,7 +116,17 @@ const Modal = ({
           ))}
         </section>
 
-        <ItemCount count={idList.length} />
+        <div className="flex items-center justify-between pr-3">
+          <ItemCount count={idList.length} />
+          <button
+            type="button"
+            className="button"
+            disabled={selectedStatus === null || processing}
+            onClick={handleChangeStatus}
+          >
+            승인
+          </button>
+        </div>
         <TableHeader
           TABLE_COLUMNS={STATUS_CHANGE_ITEMS}
           keyPrefix={"change-"}

--- a/src/app/(admin)/admin/_components/modal/modal.tsx
+++ b/src/app/(admin)/admin/_components/modal/modal.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import { createPortal } from "react-dom";
+import Cancel from "@/public/icons/common/cancel.svg";
+import { DELIVERY_STATUS } from "@/constants/delivery-status";
+import { useState } from "react";
+import { DeliveryStatus } from "../deliveryStatus/delivery-status";
+import { TableHeader } from "../table/table-header";
+import { STATUS_CHANGE_ITEMS } from "../table/table-items";
+import ItemCount from "../table/item-count";
+import { IndividualsDto, InstitutionsDto } from "@/types/admin-dto";
+import { TableItem } from "../table/table-item";
+
+const Modal = ({
+  idList,
+  items,
+  onClose,
+  handleCheckboxChange,
+}: {
+  idList: number[];
+  items: InstitutionsDto[] | IndividualsDto[];
+  onClose: () => void;
+  handleCheckboxChange: (id: number, checked: boolean) => void;
+}) => {
+  const [selectedStatus, setStatus] = useState<
+    keyof typeof DELIVERY_STATUS | null
+  >(null);
+  const targetList = items
+    .map((item) => {
+      if ("institutionId" in item) {
+        if (idList.includes(item.institutionId))
+          return {
+            id: item.institutionId,
+            name: item.name,
+            code: item.code,
+            deliveryStatus: item.deliveryStatus,
+          };
+      } else {
+        if (idList.includes(item.archiveId))
+          return {
+            id: item.archiveId,
+            name: item.receiverName,
+            code: item.archiveId,
+            deliveryStatus: item.deliveryStatus,
+          };
+      }
+    })
+    .filter((item) => item !== undefined);
+  console.log("targetList", targetList);
+  console.log("idList", idList);
+
+  return createPortal(
+    <div className="modal-bg top-0 left-0 flex h-full w-full items-center justify-center">
+      <div className="modal-main w-4xl rounded p-6">
+        <section className="flex justify-between">
+          <h1 className="text-headline-1">상태 변경 하기</h1>
+          <button type="button" onClick={onClose}>
+            <Cancel />
+          </button>
+        </section>
+
+        <section className="flex gap-20 p-4">
+          {Object.entries(DELIVERY_STATUS).map(([key, { value }]) => (
+            <div
+              className="flex gap-2"
+              key={key}
+              onClick={() => setStatus(value as keyof typeof DELIVERY_STATUS)}
+            >
+              <input
+                type="radio"
+                name={value}
+                value={value}
+                checked={value === selectedStatus}
+                onChange={() =>
+                  setStatus(value as keyof typeof DELIVERY_STATUS)
+                }
+              />
+              {DeliveryStatus(value)}
+            </div>
+          ))}
+        </section>
+
+        <ItemCount count={idList.length} />
+        <TableHeader
+          TABLE_COLUMNS={STATUS_CHANGE_ITEMS}
+          keyPrefix={"change-"}
+        />
+        <section className="overflow-auto-hide-scroll h-[400px]">
+          {targetList.map((target, index) => (
+            <TableItem
+              key={"target" + index}
+              TABLE_COLUMNS={STATUS_CHANGE_ITEMS}
+              index={index + 1}
+              id={target.id}
+              item={{ ...target, selectedStatus: selectedStatus }}
+              action={handleCheckboxChange}
+            />
+          ))}
+        </section>
+      </div>
+    </div>,
+    document.body,
+  );
+};
+
+export default Modal;

--- a/src/app/(admin)/admin/_components/month-picker/index.tsx
+++ b/src/app/(admin)/admin/_components/month-picker/index.tsx
@@ -6,30 +6,20 @@ import { useSuperAdminStore } from "@/stores/admin/useSuperAdminStroe";
 import { useRef } from "react";
 
 const MonthPicker = () => {
-  const { pivotDate, setPivotDate } = useSuperAdminStore();
+  const { pivotDate, updatePivotDate, setPivotDate } = useSuperAdminStore();
+  const date = new Date(pivotDate);
   const monthRef = useRef<HTMLInputElement>(null);
+  console.log(pivotDate);
   return (
     <section className="flex w-full flex-col items-center justify-center">
       <div className="text-headline-0 text-grey-700 flex gap-4">
-        <button
-          onClick={() =>
-            setPivotDate(
-              new Date(pivotDate.getFullYear(), pivotDate.getMonth() - 1, 1),
-            )
-          }
-        >
+        <button onClick={() => updatePivotDate(-1)}>
           <ArrowBack />
         </button>
         <button onClick={() => monthRef.current?.showPicker()}>
-          {pivotDate.getFullYear()}년 {pivotDate.getMonth()}월
+          {date.getFullYear()}년 {date.getMonth()}월
         </button>
-        <button
-          onClick={() =>
-            setPivotDate(
-              new Date(pivotDate.getFullYear(), pivotDate.getMonth() + 1, 1),
-            )
-          }
-        >
+        <button onClick={() => updatePivotDate(1)}>
           <ArrowFront />
         </button>
       </div>
@@ -37,8 +27,8 @@ const MonthPicker = () => {
       <input
         ref={monthRef}
         type="month"
-        value={`${pivotDate.getFullYear()}-${String(pivotDate.getMonth() + 1).padStart(2, "0")}`}
-        onChange={(e) => setPivotDate(new Date(e.target.value))}
+        value={`${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}`}
+        onChange={(e) => setPivotDate(e.target.value)}
         className="opacity-0"
       />
     </section>

--- a/src/app/(admin)/admin/_components/month-picker/index.tsx
+++ b/src/app/(admin)/admin/_components/month-picker/index.tsx
@@ -8,7 +8,6 @@ import { useRef } from "react";
 const MonthPicker = () => {
   const { pivotDate, updatePivotDate, setPivotDate } = useSuperAdminStore();
   const monthRef = useRef<HTMLInputElement>(null);
-  console.log(pivotDate);
   return (
     <section className="flex w-full flex-col items-center justify-center">
       <div className="text-headline-0 text-grey-700 flex gap-4">

--- a/src/app/(admin)/admin/_components/month-picker/index.tsx
+++ b/src/app/(admin)/admin/_components/month-picker/index.tsx
@@ -2,10 +2,11 @@
 
 import ArrowBack from "@/public/icons/common/arrow_back_ios.svg";
 import ArrowFront from "@/public/icons/common/arrow_front_ios.svg";
-import { useRef, useState } from "react";
+import { useSuperAdminStore } from "@/stores/admin/useSuperAdminStroe";
+import { useRef } from "react";
 
 const MonthPicker = () => {
-  const [pivotDate, setPivotDate] = useState(new Date());
+  const { pivotDate, setPivotDate } = useSuperAdminStore();
   const monthRef = useRef<HTMLInputElement>(null);
   return (
     <section className="flex w-full flex-col items-center justify-center">
@@ -20,7 +21,7 @@ const MonthPicker = () => {
           <ArrowBack />
         </button>
         <button onClick={() => monthRef.current?.showPicker()}>
-          {pivotDate.getFullYear()}년 {pivotDate.getMonth() + 1}월
+          {pivotDate.getFullYear()}년 {pivotDate.getMonth()}월
         </button>
         <button
           onClick={() =>

--- a/src/app/(admin)/admin/_components/month-picker/index.tsx
+++ b/src/app/(admin)/admin/_components/month-picker/index.tsx
@@ -7,6 +7,7 @@ import { useRef } from "react";
 
 const MonthPicker = () => {
   const { pivotDate, updatePivotDate, setPivotDate } = useSuperAdminStore();
+  const date = new Date(pivotDate);
   const monthRef = useRef<HTMLInputElement>(null);
   return (
     <section className="flex w-full flex-col items-center justify-center">
@@ -15,7 +16,7 @@ const MonthPicker = () => {
           <ArrowBack />
         </button>
         <button onClick={() => monthRef.current?.showPicker()}>
-          {pivotDate.getFullYear()}년 {pivotDate.getMonth()}월
+          {date.getFullYear()}년 {date.getMonth()}월
         </button>
         <button onClick={() => updatePivotDate(1)}>
           <ArrowFront />
@@ -25,7 +26,7 @@ const MonthPicker = () => {
       <input
         ref={monthRef}
         type="month"
-        value={`${pivotDate.getFullYear()}-${String(pivotDate.getMonth() + 1).padStart(2, "0")}`}
+        value={`${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}`}
         onChange={(e) => setPivotDate(e.target.value)}
         className="opacity-0"
       />

--- a/src/app/(admin)/admin/_components/month-picker/index.tsx
+++ b/src/app/(admin)/admin/_components/month-picker/index.tsx
@@ -7,7 +7,6 @@ import { useRef } from "react";
 
 const MonthPicker = () => {
   const { pivotDate, updatePivotDate, setPivotDate } = useSuperAdminStore();
-  const date = new Date(pivotDate);
   const monthRef = useRef<HTMLInputElement>(null);
   console.log(pivotDate);
   return (
@@ -17,7 +16,7 @@ const MonthPicker = () => {
           <ArrowBack />
         </button>
         <button onClick={() => monthRef.current?.showPicker()}>
-          {date.getFullYear()}년 {date.getMonth()}월
+          {pivotDate.getFullYear()}년 {pivotDate.getMonth()}월
         </button>
         <button onClick={() => updatePivotDate(1)}>
           <ArrowFront />
@@ -27,7 +26,7 @@ const MonthPicker = () => {
       <input
         ref={monthRef}
         type="month"
-        value={`${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}`}
+        value={`${pivotDate.getFullYear()}-${String(pivotDate.getMonth() + 1).padStart(2, "0")}`}
         onChange={(e) => setPivotDate(e.target.value)}
         className="opacity-0"
       />

--- a/src/app/(admin)/admin/_components/table/add-inst-table-item.tsx
+++ b/src/app/(admin)/admin/_components/table/add-inst-table-item.tsx
@@ -104,7 +104,7 @@ export const AddInstitutionTableItem = ({
           name={ADD_INSTITUTIONS_TABLE_ITEMS[5].value}
           onChange={handleChangeInput}
           type="tel"
-          pattern="([0-9]{3}-[0-9]{3}-[0-9]{4})|([0-9]{2}-[0-9]{3}-[0-9]{4})|([0-9]{3}-[0-9]{4}-[0-9]{4})"
+          pattern="([0-9]{3}-[0-9]{3}-[0-9]{4})|([0-9]{2}-[0-9]{3}-[0-9]{4})|([0-9]{3}-[0-9]{4}-[0-9]{4})|([0-9]{2}-[0-9]{4}-[0-9]{4})"
           placeholder="000-0000-0000"
           className="input-center"
           required

--- a/src/app/(admin)/admin/_components/table/empty-item.tsx
+++ b/src/app/(admin)/admin/_components/table/empty-item.tsx
@@ -1,0 +1,5 @@
+const EmptyItem = () => {
+  return <div className="py-20 text-center">데이터가 없습니다.</div>;
+};
+
+export default EmptyItem;

--- a/src/app/(admin)/admin/_components/table/table-header.tsx
+++ b/src/app/(admin)/admin/_components/table/table-header.tsx
@@ -1,21 +1,21 @@
 import { TableItemsType } from "./table-items";
 
 type TableHeaderProps = {
-  items: TableItemsType;
+  TABLE_COLUMNS: TableItemsType;
   keyPrefix: string; // key prefix 중복 방지용
   gap?: string; // optional로, 기본값 줄 수도 있음
   className?: string;
 };
 
 export const TableHeader = ({
-  items,
+  TABLE_COLUMNS,
   gap = "gap-4",
   keyPrefix,
   className = "",
 }: TableHeaderProps) => {
   return (
     <div className={`admin-table-header ${gap} ${className}`}>
-      {items.map(({ label, flex }, index) => (
+      {TABLE_COLUMNS.map(({ label, flex }, index) => (
         <span key={`${keyPrefix}-th-${index}`} className={flex}>
           {label}
         </span>

--- a/src/app/(admin)/admin/_components/table/table-item.tsx
+++ b/src/app/(admin)/admin/_components/table/table-item.tsx
@@ -8,7 +8,7 @@ import {
   INSTITUTIONS_TABLE_ITEMS,
 } from "./table-items";
 // import Cancel from "@/public/icons/common/cancel.svg";
-import { Families } from "@/types/admin-organization-dto";
+import { Families, OrganizationFamilies } from "@/types/admin-organization-dto";
 import Checkbox from "../button/checkbox";
 import { CheckboxProps } from "../button/checkbox-props";
 
@@ -120,7 +120,7 @@ export const InstitutionTableItem = (
         if (value === "pdfUrl")
           return (
             <span key={key} className={flex}>
-              <DownloadPdf pdfUrl={props.pdfUrl} isDownloaded={false} />
+              <DownloadPdf pdfUrl={props.pdfUrl ?? ""} isDownloaded={false} />
             </span>
           );
         if (value === "checkbox")
@@ -148,7 +148,7 @@ export const InstitutionDetailTableItem = (
   } & Families,
 ) => {
   return (
-    <div className="admin-table-item gap-2">
+    <div className="admin-table-item gap-4">
       {INSTITUTIONS_DETAIL_TABLE_ITEMS.map(({ value, flex }) => {
         const key = value + props.index;
         type Key = keyof Families;
@@ -156,6 +156,12 @@ export const InstitutionDetailTableItem = (
           return (
             <span key={key} className={flex}>
               {DeliveryStatus(props.deliveryStatus)}
+            </span>
+          );
+        if (value === "pdfUrl")
+          return (
+            <span key={key} className={flex}>
+              <DownloadPdf pdfUrl={props.pdfUrl ?? ""} isDownloaded={false} />
             </span>
           );
         return (
@@ -173,7 +179,7 @@ export const InstitutionFamilyTableItem = (
   props: {
     index: number;
     handleDeleteMember: (familyId: number) => void;
-  } & Families,
+  } & OrganizationFamilies,
 ) => {
   return (
     <Link
@@ -182,7 +188,7 @@ export const InstitutionFamilyTableItem = (
     >
       {INSTITUTION_FAMILY_TABLE_ITEMS.map(({ value, flex }) => {
         const key = value + props.index;
-        type Key = keyof Families;
+        type Key = keyof OrganizationFamilies;
         if (value === "deliveryStatus")
           return (
             <span key={key} className={flex}>

--- a/src/app/(admin)/admin/_components/table/table-item.tsx
+++ b/src/app/(admin)/admin/_components/table/table-item.tsx
@@ -24,7 +24,8 @@ interface TableItemProps {
         selectedStatus: keyof typeof DELIVERY_STATUS | null;
       };
   TABLE_COLUMNS: TableItemsType;
-  action: (id: number, checked: boolean) => void;
+  action: CheckboxProps;
+  isChecked: boolean;
   gap?: string;
   isSelected?: boolean;
   onClick?: () => void;
@@ -37,6 +38,7 @@ export const TableItem = ({
   TABLE_COLUMNS,
   action,
   gap = "gap-4",
+  isChecked,
   isSelected,
   onClick,
 }: TableItemProps) => {
@@ -69,11 +71,7 @@ export const TableItem = ({
         if (value === "checkbox")
           return (
             <span key={key} className={flex}>
-              <Checkbox
-                idValue={id}
-                callback={action}
-                isChecked={"selectedStatus" in item}
-              />
+              <Checkbox idValue={id} callback={action} isChecked={isChecked} />
             </span>
           );
         if (value === "progressUi")
@@ -122,6 +120,7 @@ export const InstitutionDetailTableItem = (
 import More from "@/public/icons/post-card/more.svg";
 import Link from "next/link";
 import { DELIVERY_STATUS } from "@/constants/delivery-status";
+import { CheckboxProps } from "../button/checkbox-props";
 export const InstitutionFamilyTableItem = (
   props: {
     index: number;

--- a/src/app/(admin)/admin/_components/table/table-item.tsx
+++ b/src/app/(admin)/admin/_components/table/table-item.tsx
@@ -2,27 +2,42 @@ import { IndividualsDto, InstitutionsDto } from "@/types/admin-dto";
 import { DeliveryStatus } from "../deliveryStatus/delivery-status";
 import { DownloadPdf } from "../button/download-pdf";
 import {
-  INDIVIDUALS_TABLE_ITEMS,
   INSTITUTION_FAMILY_TABLE_ITEMS,
   INSTITUTIONS_DETAIL_TABLE_ITEMS,
-  INSTITUTIONS_TABLE_ITEMS,
+  TableItemsType,
 } from "./table-items";
 // import Cancel from "@/public/icons/common/cancel.svg";
 import { Families, OrganizationFamilies } from "@/types/admin-organization-dto";
 import Checkbox from "../button/checkbox";
-import { CheckboxProps } from "../button/checkbox-props";
 
 interface TableItemProps {
   index: number;
   id: number;
   item: IndividualsDto | InstitutionsDto;
-  action: (id: number) => void;
+  TABLE_COLUMNS: TableItemsType;
+  action: (id: number, checked: boolean) => void;
+  gap?: string;
+  isSelected?: boolean;
+  onClick?: () => void;
 }
 
-export const TableItem = ({ index, id, item, action }: TableItemProps) => {
+export const TableItem = ({
+  index,
+  id,
+  item,
+  TABLE_COLUMNS,
+  action,
+  gap = "gap-4",
+  isSelected,
+  onClick,
+}: TableItemProps) => {
   return (
-    <div className="admin-table-item gap-4">
-      {INDIVIDUALS_TABLE_ITEMS.map(({ value, flex }) => {
+    <div
+      className={`admin-table-item ${gap} data-[status=selected]:bg-green-100`}
+      data-status={isSelected && "selected"}
+      onClick={onClick}
+    >
+      {TABLE_COLUMNS.map(({ value, flex }: { value: string; flex: string }) => {
         const key = value + index;
         if (value === "deliveryStatus")
           return (
@@ -33,7 +48,7 @@ export const TableItem = ({ index, id, item, action }: TableItemProps) => {
         if (value === "pdfUrl")
           return (
             <span key={key} className={flex}>
-              <DownloadPdf pdfUrl={item.pdfUrl} isDownloaded={false} />
+              <DownloadPdf pdfUrl={item.pdfUrl ?? ""} isDownloaded={false} />
             </span>
           );
         if (value === "checkbox")
@@ -44,97 +59,7 @@ export const TableItem = ({ index, id, item, action }: TableItemProps) => {
           );
         return (
           <span key={key} className={flex}>
-            {item[value as keyof typeof item]}
-          </span>
-        );
-      })}
-    </div>
-  );
-};
-
-export const IndividualTableItem = (
-  props: {
-    index: number;
-    handleCheckboxChange: CheckboxProps;
-  } & IndividualsDto,
-) => {
-  return (
-    <div className="admin-table-item gap-4">
-      {INDIVIDUALS_TABLE_ITEMS.map(({ value, flex }) => {
-        const key = value + props.index;
-        type Key = keyof IndividualsDto;
-        if (value === "deliveryStatus")
-          return (
-            <span key={key} className={flex}>
-              {DeliveryStatus(props.deliveryStatus)}
-            </span>
-          );
-        if (value === "pdfUrl")
-          return (
-            <span key={key} className={flex}>
-              <DownloadPdf pdfUrl={props.pdfUrl} isDownloaded={false} />
-            </span>
-          );
-        if (value === "checkbox")
-          return (
-            <span key={key} className={flex}>
-              <Checkbox
-                idValue={props.archiveId}
-                callback={props.handleCheckboxChange}
-              />
-            </span>
-          );
-        return (
-          <span key={key} className={flex}>
-            {props[value as Key]}
-          </span>
-        );
-      })}
-    </div>
-  );
-};
-
-export const InstitutionTableItem = (
-  props: {
-    index: number;
-    isSelected: boolean;
-    handleCheckboxChange: CheckboxProps;
-    onClick: () => void;
-  } & InstitutionsDto,
-) => {
-  return (
-    <div
-      className="admin-table-item gap-2 data-[status=selected]:bg-green-100"
-      data-status={props.isSelected && "selected"}
-      onClick={props.onClick}
-    >
-      {INSTITUTIONS_TABLE_ITEMS.map(({ value, flex }) => {
-        const key = value + props.index;
-        type Key = keyof InstitutionsDto;
-        if (value === "deliveryStatus")
-          return (
-            <span key={key} className={flex}>
-              {DeliveryStatus(props.deliveryStatus)}
-            </span>
-          );
-        if (value === "pdfUrl")
-          return (
-            <span key={key} className={flex}>
-              <DownloadPdf pdfUrl={props.pdfUrl ?? ""} isDownloaded={false} />
-            </span>
-          );
-        if (value === "checkbox")
-          return (
-            <span key={key} className={flex}>
-              <Checkbox
-                idValue={props.institutionId}
-                callback={props.handleCheckboxChange}
-              />
-            </span>
-          );
-        return (
-          <span key={key} className={flex}>
-            {props[value as Key]}
+            {item[value as keyof typeof item] ?? index}
           </span>
         );
       })}

--- a/src/app/(admin)/admin/_components/table/table-item.tsx
+++ b/src/app/(admin)/admin/_components/table/table-item.tsx
@@ -13,7 +13,16 @@ import Checkbox from "../button/checkbox";
 interface TableItemProps {
   index: number;
   id: number;
-  item: IndividualsDto | InstitutionsDto;
+  item:
+    | IndividualsDto
+    | InstitutionsDto
+    | {
+        id: number;
+        name: string;
+        code: number | string;
+        deliveryStatus: string;
+        selectedStatus: keyof typeof DELIVERY_STATUS | null;
+      };
   TABLE_COLUMNS: TableItemsType;
   action: (id: number, checked: boolean) => void;
   gap?: string;
@@ -45,7 +54,13 @@ export const TableItem = ({
               {DeliveryStatus(item.deliveryStatus)}
             </span>
           );
-        if (value === "pdfUrl")
+        if ("selectedStatus" in item && value === "selectedStatus")
+          return (
+            <span key={key} className={flex}>
+              {DeliveryStatus(item.selectedStatus ?? "")}
+            </span>
+          );
+        if ("pdfUrl" in item && value === "pdfUrl")
           return (
             <span key={key} className={flex}>
               <DownloadPdf pdfUrl={item.pdfUrl ?? ""} isDownloaded={false} />
@@ -54,9 +69,15 @@ export const TableItem = ({
         if (value === "checkbox")
           return (
             <span key={key} className={flex}>
-              <Checkbox idValue={id} callback={action} />
+              <Checkbox
+                idValue={id}
+                callback={action}
+                isChecked={"selectedStatus" in item}
+              />
             </span>
           );
+        if (value === "progressUi")
+          return <span key={key} className={flex}>{`->`}</span>;
         return (
           <span key={key} className={flex}>
             {item[value as keyof typeof item] ?? index}
@@ -100,6 +121,7 @@ export const InstitutionDetailTableItem = (
 };
 import More from "@/public/icons/post-card/more.svg";
 import Link from "next/link";
+import { DELIVERY_STATUS } from "@/constants/delivery-status";
 export const InstitutionFamilyTableItem = (
   props: {
     index: number;

--- a/src/app/(admin)/admin/_components/table/table-items.ts
+++ b/src/app/(admin)/admin/_components/table/table-items.ts
@@ -6,7 +6,7 @@ export type TableItemsType = {
 
 export const INDIVIDUALS_TABLE_ITEMS = [
   { value: "index", label: "번호", flex: "flex-[1]" },
-  { value: "name", label: "성함", flex: "flex-[2]" },
+  { value: "receiverName", label: "성함", flex: "flex-[2]" },
   { value: "address", label: "주소", flex: "flex-[6]" },
   { value: "addressDetail", label: "상세 주소", flex: "flex-[6]" },
   {

--- a/src/app/(admin)/admin/_components/table/table-items.ts
+++ b/src/app/(admin)/admin/_components/table/table-items.ts
@@ -67,3 +67,13 @@ export const INSTITUTION_FAMILY_TABLE_ITEMS = [
   { value: "", label: "", flex: "flex-[5]" },
   { value: "delete", label: "상세보기", flex: "flex-[1]" },
 ];
+
+export const STATUS_CHANGE_ITEMS = [
+  { value: "index", label: "번호", flex: "flex-[1]" },
+  { value: "name", label: "기관 이름", flex: "flex-[3]" },
+  { value: "code", label: "기관 코드", flex: "flex-[2]" },
+  { value: "deliveryStatus", label: "현재 상태", flex: "flex-[2] flex-center" },
+  { value: "progressUi", label: "", flex: "flex-[1] flex-center" },
+  { value: "selectedStatus", label: "변경 상태", flex: "flex-[2] flex-center" },
+  { value: "checkbox", label: "관리", flex: "flex-[1] flex-center" },
+];

--- a/src/app/(admin)/admin/_components/viewer/institution-detail.tsx
+++ b/src/app/(admin)/admin/_components/viewer/institution-detail.tsx
@@ -10,7 +10,7 @@ const InstitutionDetail = ({ families }: { families: Families[] }) => {
     <div>
       <ItemCount count={families.length} />
       <TableHeader
-        items={INSTITUTIONS_DETAIL_TABLE_ITEMS}
+        TABLE_COLUMNS={INSTITUTIONS_DETAIL_TABLE_ITEMS}
         keyPrefix={"inst-detail"}
       />
       {families.map((item, index) => (

--- a/src/app/(admin)/admin/_components/viewer/institution-detail.tsx
+++ b/src/app/(admin)/admin/_components/viewer/institution-detail.tsx
@@ -3,10 +3,12 @@ import React from "react";
 import { TableHeader } from "../table/table-header";
 import { INSTITUTIONS_DETAIL_TABLE_ITEMS } from "../table/table-items";
 import { InstitutionDetailTableItem } from "../table/table-item";
+import ItemCount from "../table/item-count";
 
 const InstitutionDetail = ({ families }: { families: Families[] }) => {
   return (
     <div>
+      <ItemCount count={families.length} />
       <TableHeader
         items={INSTITUTIONS_DETAIL_TABLE_ITEMS}
         keyPrefix={"inst-detail"}

--- a/src/app/(admin)/admin/_components/viewer/table-viewer.tsx
+++ b/src/app/(admin)/admin/_components/viewer/table-viewer.tsx
@@ -11,6 +11,7 @@ import MonthPicker from "../month-picker";
 import ItemCount from "../table/item-count";
 import ChangeStatus from "../button/change-status";
 import MoreView from "../button/more-view";
+import Modal from "../modal/modal";
 
 interface TableViewerProps {
   items: InstitutionsDto[] | IndividualsDto[];
@@ -41,6 +42,8 @@ const TableViewer = ({
   const [viewLevel, setViewLevel] = useState(1);
   const viewItem = items.slice(0, viewLevel * 8);
 
+  const [open, setOpen] = useState(false);
+
   useEffect(() => {
     const fetchData = async () => {
       const date = new Date(pivotDate);
@@ -54,6 +57,10 @@ const TableViewer = ({
     else
       setCheckedItem((prev) => prev.filter((selectedId) => selectedId !== id));
   };
+
+  const handleChangeStatus = () => {
+    setOpen(true);
+  };
   return (
     <div className="bg-grey-0 w-full">
       <PageToggle curPage={curPageNum} />
@@ -62,7 +69,10 @@ const TableViewer = ({
         <ItemCount count={items.length} />
 
         <div className="flex items-center gap-4">
-          <ChangeStatus selectedItemCount={checkedItem.length} />
+          <ChangeStatus
+            selectedItemCount={checkedItem.length}
+            onClick={handleChangeStatus}
+          />
         </div>
       </div>
       <TableHeader
@@ -105,6 +115,15 @@ const TableViewer = ({
         count={items.length}
         onClick={() => setViewLevel((prev) => prev + 1)}
       />
+
+      {open && (
+        <Modal
+          idList={checkedItem}
+          items={items}
+          onClose={() => setOpen(false)}
+          handleCheckboxChange={handleCheckboxChange}
+        />
+      )}
     </div>
   );
 };

--- a/src/app/(admin)/admin/_components/viewer/table-viewer.tsx
+++ b/src/app/(admin)/admin/_components/viewer/table-viewer.tsx
@@ -16,7 +16,6 @@ import Modal from "../modal/modal";
 interface TableViewerProps {
   items: InstitutionsDto[] | IndividualsDto[];
   TABLE_COLUMNS: TableItemsType;
-  idName: "institutionId" | "archiveId";
   curPageNum: number;
   keyPrefix: string;
   fetchItem: (year: number, month: number) => Promise<never[] | undefined>;
@@ -29,7 +28,6 @@ const TableViewer = ({
   items,
   fetchItem,
   TABLE_COLUMNS,
-  idName,
   curPageNum,
   keyPrefix,
   gap = "gap-4",
@@ -53,9 +51,15 @@ const TableViewer = ({
   }, [pivotDate, fetchItem]);
 
   const handleCheckboxChange = (id: number, checked: boolean) => {
-    if (checked) setCheckedItem((prev) => [...prev, id]);
-    else
-      setCheckedItem((prev) => prev.filter((selectedId) => selectedId !== id));
+    setCheckedItem((prev) => {
+      const set = new Set(prev);
+      if (checked) {
+        set.add(id);
+      } else {
+        set.delete(id);
+      }
+      return Array.from(set);
+    });
   };
 
   const handleChangeStatus = () => {
@@ -87,18 +91,15 @@ const TableViewer = ({
           <TableItem
             key={index}
             index={index + 1}
-            id={
-              "institutionId" in item && idName === "institutionId"
-                ? item.institutionId
-                : "archiveId" in item && idName === "archiveId"
-                  ? item.archiveId
-                  : -1
-            }
+            id={"institutionId" in item ? item.institutionId : item.archiveId}
             item={item}
             TABLE_COLUMNS={TABLE_COLUMNS}
             action={handleCheckboxChange}
             gap={gap}
-            {...(idName === "institutionId" && "institutionId" in item
+            isChecked={checkedItem.includes(
+              "institutionId" in item ? item.institutionId : item.archiveId,
+            )}
+            {...("institutionId" in item
               ? {
                   isSelected: selectedInstitution === item.institutionId,
                   onClick: () =>

--- a/src/app/(admin)/admin/_components/viewer/table-viewer.tsx
+++ b/src/app/(admin)/admin/_components/viewer/table-viewer.tsx
@@ -123,6 +123,7 @@ const TableViewer = ({
           items={items}
           onClose={() => setOpen(false)}
           handleCheckboxChange={handleCheckboxChange}
+          resetCheckItem={() => setCheckedItem([])}
         />
       )}
     </div>

--- a/src/app/(admin)/admin/_components/viewer/table-viewer.tsx
+++ b/src/app/(admin)/admin/_components/viewer/table-viewer.tsx
@@ -1,0 +1,112 @@
+import { Dispatch, SetStateAction, useEffect, useState } from "react";
+import { IndividualsDto, InstitutionsDto } from "@/types/admin-dto";
+import { useSuperAdminStore } from "@/stores/admin/useSuperAdminStroe";
+
+import { TableItemsType } from "../table/table-items";
+import { TableHeader } from "../table/table-header";
+import { TableItem } from "../table/table-item";
+import EmptyItem from "../table/empty-item";
+import PageToggle from "../button/page-toggle";
+import MonthPicker from "../month-picker";
+import ItemCount from "../table/item-count";
+import ChangeStatus from "../button/change-status";
+import MoreView from "../button/more-view";
+
+interface TableViewerProps {
+  items: InstitutionsDto[] | IndividualsDto[];
+  TABLE_COLUMNS: TableItemsType;
+  idName: "institutionId" | "archiveId";
+  curPageNum: number;
+  keyPrefix: string;
+  fetchItem: (year: number, month: number) => Promise<never[] | undefined>;
+  gap?: string;
+
+  selectedInstitution?: number | null;
+  setSelecedInstitution?: Dispatch<SetStateAction<number | null>>;
+}
+const TableViewer = ({
+  items,
+  fetchItem,
+  TABLE_COLUMNS,
+  idName,
+  curPageNum,
+  keyPrefix,
+  gap = "gap-4",
+  selectedInstitution,
+  setSelecedInstitution,
+}: TableViewerProps) => {
+  const [checkedItem, setCheckedItem] = useState<number[]>([]);
+  const { pivotDate } = useSuperAdminStore();
+
+  const [viewLevel, setViewLevel] = useState(1);
+  const viewItem = items.slice(0, viewLevel * 8);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      const date = new Date(pivotDate);
+      await fetchItem(date.getFullYear(), date.getMonth()); //함수만 다름
+    };
+    fetchData();
+  }, [pivotDate, fetchItem]);
+
+  const handleCheckboxChange = (id: number, checked: boolean) => {
+    if (checked) setCheckedItem((prev) => [...prev, id]);
+    else
+      setCheckedItem((prev) => prev.filter((selectedId) => selectedId !== id));
+  };
+  return (
+    <div className="bg-grey-0 w-full">
+      <PageToggle curPage={curPageNum} />
+      <MonthPicker />
+      <div className="flex justify-between">
+        <ItemCount count={items.length} />
+
+        <div className="flex items-center gap-4">
+          <ChangeStatus selectedItemCount={checkedItem.length} />
+        </div>
+      </div>
+      <TableHeader
+        TABLE_COLUMNS={TABLE_COLUMNS}
+        keyPrefix={keyPrefix}
+        gap={gap}
+      />
+      {items.length === 0 ? (
+        <EmptyItem />
+      ) : (
+        viewItem.map((item, index) => (
+          <TableItem
+            key={index}
+            index={index + 1}
+            id={
+              "institutionId" in item && idName === "institutionId"
+                ? item.institutionId
+                : "archiveId" in item && idName === "archiveId"
+                  ? item.archiveId
+                  : -1
+            }
+            item={item}
+            TABLE_COLUMNS={TABLE_COLUMNS}
+            action={handleCheckboxChange}
+            gap={gap}
+            {...(idName === "institutionId" && "institutionId" in item
+              ? {
+                  isSelected: selectedInstitution === item.institutionId,
+                  onClick: () =>
+                    setSelecedInstitution?.((prev) =>
+                      prev === item.institutionId ? null : item.institutionId,
+                    ),
+                }
+              : {})}
+          />
+        ))
+      )}
+      <MoreView
+        viewLevel={viewLevel}
+        count={items.length}
+        onClick={() => setViewLevel((prev) => prev + 1)}
+      />
+    </div>
+  );
+};
+
+export default TableViewer;

--- a/src/app/(admin)/admin/master/individual/page.tsx
+++ b/src/app/(admin)/admin/master/individual/page.tsx
@@ -20,11 +20,10 @@ const Page = () => {
 
   useEffect(() => {
     const fetchData = async () => {
-      const date = new Date(pivotDate);
-      await getHomeArchives(date.getFullYear(), date.getMonth());
+      await getHomeArchives(pivotDate.getFullYear(), pivotDate.getMonth());
     };
     fetchData();
-  }, []);
+  }, [pivotDate]);
 
   const handleCheckboxChange = (archiveId: number, checked: boolean) => {
     if (checked) setCheckedItem((prev) => [...prev, archiveId]);

--- a/src/app/(admin)/admin/master/individual/page.tsx
+++ b/src/app/(admin)/admin/master/individual/page.tsx
@@ -1,73 +1,25 @@
 "use client";
 
 import { useSuperAdminStore } from "@/stores/admin/useSuperAdminStroe";
-import { useEffect, useState } from "react";
-import PageToggle from "../../_components/button/page-toggle";
-import ItemCount from "../../_components/table/item-count";
-import ChangeStatus from "../../_components/button/change-status";
-import { TableHeader } from "../../_components/table/table-header";
-import { TableItem } from "../../_components/table/table-item";
-import MoreView from "../../_components/button/more-view";
+
 import { DELIVERY_TYPE } from "@/constants/delivery-type";
-import { INDIVIDUALS_TABLE_ITEMS } from "../../_components/table/table-items";
-import MonthPicker from "../../_components/month-picker";
-import EmptyItem from "../../_components/table/empty-item";
 import { getHomeArchives } from "@/api/admin";
 
+import { INDIVIDUALS_TABLE_ITEMS } from "../../_components/table/table-items";
+import TableViewer from "../../_components/viewer/table-viewer";
+
 const Page = () => {
-  const [checkedItem, setCheckedItem] = useState<number[]>([]);
-  const { individuals, pivotDate } = useSuperAdminStore(); //개별
+  const { individuals } = useSuperAdminStore(); //개별
 
-  const [viewLevel, setViewLevel] = useState(1);
-  const viewIndividuals = individuals.slice(0, viewLevel * 8);
-
-  useEffect(() => {
-    const fetchData = async () => {
-      const date = new Date(pivotDate);
-      await getHomeArchives(date.getFullYear(), date.getMonth()); //함수만 다름
-    };
-    fetchData();
-  }, [pivotDate]);
-
-  const handleCheckboxChange = (archiveId: number, checked: boolean) => {
-    if (checked) setCheckedItem((prev) => [...prev, archiveId]);
-    else
-      setCheckedItem((prev) =>
-        prev.filter((selectedId) => selectedId !== archiveId),
-      );
-  };
   return (
-    <div className="bg-grey-0 w-full">
-      <PageToggle curPage={DELIVERY_TYPE.HOME} />
-      <MonthPicker />
-      <div className="flex justify-between">
-        <ItemCount count={individuals.length} />
-
-        <div className="flex items-center gap-4">
-          <ChangeStatus selectedItemCount={checkedItem.length} />
-        </div>
-      </div>
-      <TableHeader items={INDIVIDUALS_TABLE_ITEMS} keyPrefix={"inv-th"} />
-      {individuals.length === 0 ? (
-        <EmptyItem />
-      ) : (
-        viewIndividuals.map((item, index) => (
-          <TableItem
-            key={index}
-            index={index + 1}
-            id={item.archiveId}
-            item={item}
-            TABLE_COLUMNS={INDIVIDUALS_TABLE_ITEMS}
-            action={handleCheckboxChange}
-          />
-        ))
-      )}
-      <MoreView
-        viewLevel={viewLevel}
-        count={viewIndividuals.length}
-        onClick={() => setViewLevel((prev) => prev + 1)}
-      />
-    </div>
+    <TableViewer
+      items={individuals}
+      TABLE_COLUMNS={INDIVIDUALS_TABLE_ITEMS}
+      idName={"archiveId"}
+      curPageNum={DELIVERY_TYPE.HOME}
+      keyPrefix={"home-th"}
+      fetchItem={getHomeArchives}
+    />
   );
 };
 

--- a/src/app/(admin)/admin/master/individual/page.tsx
+++ b/src/app/(admin)/admin/master/individual/page.tsx
@@ -6,7 +6,7 @@ import PageToggle from "../../_components/button/page-toggle";
 import ItemCount from "../../_components/table/item-count";
 import ChangeStatus from "../../_components/button/change-status";
 import { TableHeader } from "../../_components/table/table-header";
-import { IndividualTableItem } from "../../_components/table/table-item";
+import { TableItem } from "../../_components/table/table-item";
 import MoreView from "../../_components/button/more-view";
 import { DELIVERY_TYPE } from "@/constants/delivery-type";
 import { INDIVIDUALS_TABLE_ITEMS } from "../../_components/table/table-items";
@@ -16,7 +16,7 @@ import { getHomeArchives } from "@/api/admin";
 
 const Page = () => {
   const [checkedItem, setCheckedItem] = useState<number[]>([]);
-  const { individuals, pivotDate } = useSuperAdminStore();
+  const { individuals, pivotDate } = useSuperAdminStore(); //개별
 
   const [viewLevel, setViewLevel] = useState(1);
   const viewIndividuals = individuals.slice(0, viewLevel * 8);
@@ -24,7 +24,7 @@ const Page = () => {
   useEffect(() => {
     const fetchData = async () => {
       const date = new Date(pivotDate);
-      await getHomeArchives(date.getFullYear(), date.getMonth());
+      await getHomeArchives(date.getFullYear(), date.getMonth()); //함수만 다름
     };
     fetchData();
   }, [pivotDate]);
@@ -52,11 +52,13 @@ const Page = () => {
         <EmptyItem />
       ) : (
         viewIndividuals.map((item, index) => (
-          <IndividualTableItem
+          <TableItem
             key={index}
             index={index + 1}
-            {...item}
-            handleCheckboxChange={handleCheckboxChange}
+            id={item.archiveId}
+            item={item}
+            TABLE_COLUMNS={INDIVIDUALS_TABLE_ITEMS}
+            action={handleCheckboxChange}
           />
         ))
       )}

--- a/src/app/(admin)/admin/master/individual/page.tsx
+++ b/src/app/(admin)/admin/master/individual/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useSuperAdminStore } from "@/stores/admin/useSuperAdminStroe";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import PageToggle from "../../_components/button/page-toggle";
 import ItemCount from "../../_components/table/item-count";
 import ChangeStatus from "../../_components/button/change-status";
@@ -11,10 +11,20 @@ import MoreView from "../../_components/button/more-view";
 import { DELIVERY_TYPE } from "@/constants/delivery-type";
 import { INDIVIDUALS_TABLE_ITEMS } from "../../_components/table/table-items";
 import MonthPicker from "../../_components/month-picker";
+import EmptyItem from "../../_components/table/empty-item";
+import { getHomeArchives } from "@/api/admin";
 
 const Page = () => {
   const [checkedItem, setCheckedItem] = useState<number[]>([]);
-  const { individuals } = useSuperAdminStore();
+  const { individuals, pivotDate } = useSuperAdminStore();
+
+  useEffect(() => {
+    const fetchData = async () => {
+      const date = new Date(pivotDate);
+      await getHomeArchives(date.getFullYear(), date.getMonth());
+    };
+    fetchData();
+  }, []);
 
   const handleCheckboxChange = (archiveId: number, checked: boolean) => {
     if (checked) setCheckedItem((prev) => [...prev, archiveId]);
@@ -35,14 +45,18 @@ const Page = () => {
         </div>
       </div>
       <TableHeader items={INDIVIDUALS_TABLE_ITEMS} keyPrefix={"inv-th"} />
-      {individuals.map((item, index) => (
-        <IndividualTableItem
-          key={index}
-          index={index + 1}
-          {...item}
-          handleCheckboxChange={handleCheckboxChange}
-        />
-      ))}
+      {individuals.length === 0 ? (
+        <EmptyItem />
+      ) : (
+        individuals.map((item, index) => (
+          <IndividualTableItem
+            key={index}
+            index={index + 1}
+            {...item}
+            handleCheckboxChange={handleCheckboxChange}
+          />
+        ))
+      )}
       <MoreView viewLevel={1} count={individuals.length} />
     </div>
   );

--- a/src/app/(admin)/admin/master/individual/page.tsx
+++ b/src/app/(admin)/admin/master/individual/page.tsx
@@ -15,7 +15,6 @@ const Page = () => {
     <TableViewer
       items={individuals}
       TABLE_COLUMNS={INDIVIDUALS_TABLE_ITEMS}
-      idName={"archiveId"}
       curPageNum={DELIVERY_TYPE.HOME}
       keyPrefix={"home-th"}
       fetchItem={getHomeArchives}

--- a/src/app/(admin)/admin/master/individual/page.tsx
+++ b/src/app/(admin)/admin/master/individual/page.tsx
@@ -18,6 +18,9 @@ const Page = () => {
   const [checkedItem, setCheckedItem] = useState<number[]>([]);
   const { individuals, pivotDate } = useSuperAdminStore();
 
+  const [viewLevel, setViewLevel] = useState(1);
+  const viewIndividuals = individuals.slice(0, viewLevel * 8);
+
   useEffect(() => {
     const fetchData = async () => {
       const date = new Date(pivotDate);
@@ -48,7 +51,7 @@ const Page = () => {
       {individuals.length === 0 ? (
         <EmptyItem />
       ) : (
-        individuals.map((item, index) => (
+        viewIndividuals.map((item, index) => (
           <IndividualTableItem
             key={index}
             index={index + 1}
@@ -57,7 +60,11 @@ const Page = () => {
           />
         ))
       )}
-      <MoreView viewLevel={1} count={individuals.length} />
+      <MoreView
+        viewLevel={viewLevel}
+        count={viewIndividuals.length}
+        onClick={() => setViewLevel((prev) => prev + 1)}
+      />
     </div>
   );
 };

--- a/src/app/(admin)/admin/master/individual/page.tsx
+++ b/src/app/(admin)/admin/master/individual/page.tsx
@@ -20,7 +20,8 @@ const Page = () => {
 
   useEffect(() => {
     const fetchData = async () => {
-      await getHomeArchives(pivotDate.getFullYear(), pivotDate.getMonth());
+      const date = new Date(pivotDate);
+      await getHomeArchives(date.getFullYear(), date.getMonth());
     };
     fetchData();
   }, [pivotDate]);

--- a/src/app/(admin)/admin/master/institution-add/page.tsx
+++ b/src/app/(admin)/admin/master/institution-add/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 import { ADD_INSTITUTION } from "@/constants/delivery-type";
 import PageToggle from "../../_components/button/page-toggle";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import ItemCount from "../../_components/table/item-count";
 import { TableHeader } from "../../_components/table/table-header";
 import MoreAdd from "../../_components/button/more-add";
@@ -29,10 +29,6 @@ const Page = () => {
   const [institutionList, setInstitutionList] = useState<AddInstitutionProps[]>(
     [DEFAULT],
   );
-
-  useEffect(() => {
-    console.log("institutionList", institutionList);
-  }, [institutionList]);
 
   const handleMoreAdd = () => setInstitutionList((prev) => [...prev, DEFAULT]);
   const handleDeleteAdd = (index: number) => {

--- a/src/app/(admin)/admin/master/institution-add/page.tsx
+++ b/src/app/(admin)/admin/master/institution-add/page.tsx
@@ -84,7 +84,7 @@ const Page = () => {
           </div>
         </div>
         <TableHeader
-          items={ADD_INSTITUTIONS_TABLE_ITEMS}
+          TABLE_COLUMNS={ADD_INSTITUTIONS_TABLE_ITEMS}
           keyPrefix={"add-inst-th"}
           className="break-keep"
         />

--- a/src/app/(admin)/admin/master/institution-add/page.tsx
+++ b/src/app/(admin)/admin/master/institution-add/page.tsx
@@ -8,6 +8,8 @@ import MoreAdd from "../../_components/button/more-add";
 import { AddInstitutionProps } from "@/types/admin-dto";
 import { ADD_INSTITUTIONS_TABLE_ITEMS } from "../../_components/table/table-items";
 import { AddInstitutionTableItem } from "../../_components/table/add-inst-table-item";
+import { addInstitutions } from "@/api/admin";
+import { useRouter } from "next/navigation";
 
 const DEFAULT = {
   name: "",
@@ -20,6 +22,10 @@ const DEFAULT = {
 };
 
 const Page = () => {
+  const [loading, setLoading] = useState(false);
+  // const [errorList, setErrorList] = useState([]);
+  const router = useRouter();
+
   const [institutionList, setInstitutionList] = useState<AddInstitutionProps[]>(
     [DEFAULT],
   );
@@ -32,8 +38,41 @@ const Page = () => {
   const handleDeleteAdd = (index: number) => {
     setInstitutionList((prev) => prev.filter((_, i) => i !== index));
   };
-  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
+    setLoading(true);
+    // setErrorList([]);
+
+    const results = await Promise.allSettled(
+      institutionList.map(
+        ({
+          name,
+          postalCode,
+          address,
+          addressDetail,
+          phone,
+          serviceDate,
+          members,
+        }) =>
+          addInstitutions(
+            name,
+            address + " " + addressDetail,
+            phone,
+            postalCode,
+            serviceDate,
+            members,
+          ),
+      ),
+    );
+
+    const failures = results.filter((item) => item.status === "rejected");
+
+    if (failures.length === 0) {
+      setInstitutionList([DEFAULT]);
+      router.push(process.env.NEXT_PUBLIC_MASTER_ADMIN_INSTITUTION_PATH!);
+    }
+    setLoading(false);
   };
   return (
     <div className="bg-grey-0 w-full">
@@ -43,8 +82,8 @@ const Page = () => {
           <ItemCount count={institutionList.length} />
 
           <div>
-            <button type="submit" className="button">
-              {institutionList.length}개 기관 추가
+            <button type="submit" className="button" disabled={loading}>
+              {institutionList.length}개 기관 {loading ? "처리 중..." : "추가"}
             </button>
           </div>
         </div>

--- a/src/app/(admin)/admin/master/institution/page.tsx
+++ b/src/app/(admin)/admin/master/institution/page.tsx
@@ -25,10 +25,8 @@ const Page = () => {
 
   useEffect(() => {
     const fetchData = async () => {
-      await getInstitutionArchives(
-        pivotDate.getFullYear(),
-        pivotDate.getMonth(),
-      );
+      const date = new Date(pivotDate);
+      await getInstitutionArchives(date.getFullYear(), date.getMonth());
     };
     fetchData();
   }, [pivotDate]);

--- a/src/app/(admin)/admin/master/institution/page.tsx
+++ b/src/app/(admin)/admin/master/institution/page.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from "react";
 import ItemCount from "../../_components/table/item-count";
 import ChangeStatus from "../../_components/button/change-status";
 import { TableHeader } from "../../_components/table/table-header";
-import { InstitutionTableItem } from "../../_components/table/table-item";
+import { TableItem } from "../../_components/table/table-item";
 import MoreView from "../../_components/button/more-view";
 import { DELIVERY_TYPE } from "@/constants/delivery-type";
 import PageToggle from "../../_components/button/page-toggle";
@@ -17,18 +17,19 @@ import { getInstitutionArchives } from "@/api/admin";
 
 const Page = () => {
   const [checkedItem, setCheckedItem] = useState<number[]>([]);
-  const { institutions, pivotDate } = useSuperAdminStore();
+  const { institutions, pivotDate } = useSuperAdminStore(); //개별
   const [selectedInstitution, setSelecedInstitution] = useState<null | number>(
     null,
-  );
-  const [families] = useState<Families[]>([]);
+  ); //개별
+  const [families] = useState<Families[]>([]); //개별
+
   const [viewLevel, setViewLevel] = useState(1);
   const viewInstitutions = institutions.slice(0, viewLevel * 8);
 
   useEffect(() => {
     const fetchData = async () => {
       const date = new Date(pivotDate);
-      await getInstitutionArchives(date.getFullYear(), date.getMonth());
+      await getInstitutionArchives(date.getFullYear(), date.getMonth()); //함수만 다름
     };
     fetchData();
   }, [pivotDate]);
@@ -61,11 +62,14 @@ const Page = () => {
         <EmptyItem />
       ) : (
         viewInstitutions.map((item, index) => (
-          <InstitutionTableItem
+          <TableItem
             key={index}
             index={index + 1}
-            {...item}
-            handleCheckboxChange={handleCheckboxChange}
+            id={item.institutionId}
+            item={item}
+            TABLE_COLUMNS={INSTITUTIONS_TABLE_ITEMS}
+            action={handleCheckboxChange}
+            gap="gap-2"
             isSelected={selectedInstitution === item.institutionId}
             onClick={() =>
               setSelecedInstitution((prev) =>

--- a/src/app/(admin)/admin/master/institution/page.tsx
+++ b/src/app/(admin)/admin/master/institution/page.tsx
@@ -85,7 +85,6 @@ const Page = () => {
         onClick={() => setViewLevel((prev) => prev + 1)}
       />
 
-      {selectedInstitution && <ItemCount count={families.length} />}
       {selectedInstitution && <InstitutionDetail families={families} />}
     </div>
   );

--- a/src/app/(admin)/admin/master/institution/page.tsx
+++ b/src/app/(admin)/admin/master/institution/page.tsx
@@ -23,7 +23,6 @@ const Page = () => {
       <TableViewer
         items={institutions}
         TABLE_COLUMNS={INSTITUTIONS_TABLE_ITEMS}
-        idName={"institutionId"}
         curPageNum={DELIVERY_TYPE.INSTITUTION}
         keyPrefix={"inst-th"}
         fetchItem={getInstitutionArchives}

--- a/src/app/(admin)/admin/master/institution/page.tsx
+++ b/src/app/(admin)/admin/master/institution/page.tsx
@@ -22,6 +22,8 @@ const Page = () => {
     null,
   );
   const [families] = useState<Families[]>([]);
+  const [viewLevel, setViewLevel] = useState(1);
+  const viewInstitutions = institutions.slice(0, viewLevel * 8);
 
   useEffect(() => {
     const fetchData = async () => {
@@ -58,7 +60,7 @@ const Page = () => {
       {institutions.length === 0 ? (
         <EmptyItem />
       ) : (
-        institutions.map((item, index) => (
+        viewInstitutions.map((item, index) => (
           <InstitutionTableItem
             key={index}
             index={index + 1}
@@ -73,7 +75,11 @@ const Page = () => {
           />
         ))
       )}
-      <MoreView viewLevel={1} count={institutions.length} />
+      <MoreView
+        viewLevel={viewLevel}
+        count={institutions.length}
+        onClick={() => setViewLevel((prev) => prev + 1)}
+      />
 
       {selectedInstitution && <ItemCount count={families.length} />}
       {selectedInstitution && <InstitutionDetail families={families} />}

--- a/src/app/(admin)/admin/master/institution/page.tsx
+++ b/src/app/(admin)/admin/master/institution/page.tsx
@@ -18,7 +18,6 @@ import { getInstitutionArchives } from "@/api/admin";
 const Page = () => {
   const [checkedItem, setCheckedItem] = useState<number[]>([]);
   const { institutions, pivotDate } = useSuperAdminStore();
-  const date = new Date(pivotDate);
   const [selectedInstitution, setSelecedInstitution] = useState<null | number>(
     null,
   );
@@ -26,10 +25,13 @@ const Page = () => {
 
   useEffect(() => {
     const fetchData = async () => {
-      await getInstitutionArchives(date.getFullYear(), date.getMonth());
+      await getInstitutionArchives(
+        pivotDate.getFullYear(),
+        pivotDate.getMonth(),
+      );
     };
     fetchData();
-  }, []);
+  }, [pivotDate]);
 
   const handleCheckboxChange = (institutionId: number, checked: boolean) => {
     if (checked) setCheckedItem((prev) => [...prev, institutionId]);

--- a/src/app/(admin)/admin/master/institution/page.tsx
+++ b/src/app/(admin)/admin/master/institution/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { useSuperAdminStore } from "@/stores/admin/useSuperAdminStroe";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import ItemCount from "../../_components/table/item-count";
 import ChangeStatus from "../../_components/button/change-status";
 import { TableHeader } from "../../_components/table/table-header";
@@ -11,14 +11,25 @@ import PageToggle from "../../_components/button/page-toggle";
 import { INSTITUTIONS_TABLE_ITEMS } from "../../_components/table/table-items";
 import MonthPicker from "../../_components/month-picker";
 import InstitutionDetail from "../../_components/viewer/institution-detail";
-import { mockFam } from "@/stores/admin/useOrganizationAdminStore";
+import EmptyItem from "../../_components/table/empty-item";
+import { Families } from "@/types/admin-organization-dto";
+import { getInstitutionArchives } from "@/api/admin";
 
 const Page = () => {
   const [checkedItem, setCheckedItem] = useState<number[]>([]);
-  const { institutions } = useSuperAdminStore();
+  const { institutions, pivotDate } = useSuperAdminStore();
+  const date = new Date(pivotDate);
   const [selectedInstitution, setSelecedInstitution] = useState<null | number>(
     null,
   );
+  const [families] = useState<Families[]>([]);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      await getInstitutionArchives(date.getFullYear(), date.getMonth());
+    };
+    fetchData();
+  }, []);
 
   const handleCheckboxChange = (institutionId: number, checked: boolean) => {
     if (checked) setCheckedItem((prev) => [...prev, institutionId]);
@@ -44,20 +55,28 @@ const Page = () => {
         keyPrefix={"inst-th"}
         gap="gap-2"
       />
-      {institutions.map((item, index) => (
-        <InstitutionTableItem
-          key={index}
-          index={index + 1}
-          {...item}
-          handleCheckboxChange={handleCheckboxChange}
-          isSelected={selectedInstitution === item.institutionId}
-          onClick={() => setSelecedInstitution(item.institutionId)}
-        />
-      ))}
+      {institutions.length === 0 ? (
+        <EmptyItem />
+      ) : (
+        institutions.map((item, index) => (
+          <InstitutionTableItem
+            key={index}
+            index={index + 1}
+            {...item}
+            handleCheckboxChange={handleCheckboxChange}
+            isSelected={selectedInstitution === item.institutionId}
+            onClick={() =>
+              setSelecedInstitution((prev) =>
+                prev === item.institutionId ? null : item.institutionId,
+              )
+            }
+          />
+        ))
+      )}
       <MoreView viewLevel={1} count={institutions.length} />
 
-      {selectedInstitution && <ItemCount count={mockFam.length} />}
-      {selectedInstitution && <InstitutionDetail families={mockFam} />}
+      {selectedInstitution && <ItemCount count={families.length} />}
+      {selectedInstitution && <InstitutionDetail families={families} />}
     </div>
   );
 };

--- a/src/app/(admin)/admin/master/institution/page.tsx
+++ b/src/app/(admin)/admin/master/institution/page.tsx
@@ -1,92 +1,38 @@
 "use client";
+
+import { useState } from "react";
 import { useSuperAdminStore } from "@/stores/admin/useSuperAdminStroe";
-import { useEffect, useState } from "react";
-import ItemCount from "../../_components/table/item-count";
-import ChangeStatus from "../../_components/button/change-status";
-import { TableHeader } from "../../_components/table/table-header";
-import { TableItem } from "../../_components/table/table-item";
-import MoreView from "../../_components/button/more-view";
+
 import { DELIVERY_TYPE } from "@/constants/delivery-type";
-import PageToggle from "../../_components/button/page-toggle";
-import { INSTITUTIONS_TABLE_ITEMS } from "../../_components/table/table-items";
-import MonthPicker from "../../_components/month-picker";
-import InstitutionDetail from "../../_components/viewer/institution-detail";
-import EmptyItem from "../../_components/table/empty-item";
 import { Families } from "@/types/admin-organization-dto";
 import { getInstitutionArchives } from "@/api/admin";
 
+import { INSTITUTIONS_TABLE_ITEMS } from "../../_components/table/table-items";
+import InstitutionDetail from "../../_components/viewer/institution-detail";
+import TableViewer from "../../_components/viewer/table-viewer";
+
 const Page = () => {
-  const [checkedItem, setCheckedItem] = useState<number[]>([]);
-  const { institutions, pivotDate } = useSuperAdminStore(); //개별
+  const { institutions } = useSuperAdminStore();
   const [selectedInstitution, setSelecedInstitution] = useState<null | number>(
     null,
-  ); //개별
-  const [families] = useState<Families[]>([]); //개별
-
-  const [viewLevel, setViewLevel] = useState(1);
-  const viewInstitutions = institutions.slice(0, viewLevel * 8);
-
-  useEffect(() => {
-    const fetchData = async () => {
-      const date = new Date(pivotDate);
-      await getInstitutionArchives(date.getFullYear(), date.getMonth()); //함수만 다름
-    };
-    fetchData();
-  }, [pivotDate]);
-
-  const handleCheckboxChange = (institutionId: number, checked: boolean) => {
-    if (checked) setCheckedItem((prev) => [...prev, institutionId]);
-    else
-      setCheckedItem((prev) =>
-        prev.filter((selectedId) => selectedId !== institutionId),
-      );
-  };
+  );
+  const [families] = useState<Families[]>([]);
 
   return (
-    <div className="bg-grey-0 w-full">
-      <PageToggle curPage={DELIVERY_TYPE.INSTITUTION} />
-      <MonthPicker />
-      <div className="flex justify-between">
-        <ItemCount count={institutions.length} />
-
-        <div className="flex items-center gap-4">
-          <ChangeStatus selectedItemCount={checkedItem.length} />
-        </div>
-      </div>
-      <TableHeader
-        items={INSTITUTIONS_TABLE_ITEMS}
+    <>
+      <TableViewer
+        items={institutions}
+        TABLE_COLUMNS={INSTITUTIONS_TABLE_ITEMS}
+        idName={"institutionId"}
+        curPageNum={DELIVERY_TYPE.INSTITUTION}
         keyPrefix={"inst-th"}
+        fetchItem={getInstitutionArchives}
         gap="gap-2"
+        selectedInstitution={selectedInstitution}
+        setSelecedInstitution={setSelecedInstitution}
       />
-      {institutions.length === 0 ? (
-        <EmptyItem />
-      ) : (
-        viewInstitutions.map((item, index) => (
-          <TableItem
-            key={index}
-            index={index + 1}
-            id={item.institutionId}
-            item={item}
-            TABLE_COLUMNS={INSTITUTIONS_TABLE_ITEMS}
-            action={handleCheckboxChange}
-            gap="gap-2"
-            isSelected={selectedInstitution === item.institutionId}
-            onClick={() =>
-              setSelecedInstitution((prev) =>
-                prev === item.institutionId ? null : item.institutionId,
-              )
-            }
-          />
-        ))
-      )}
-      <MoreView
-        viewLevel={viewLevel}
-        count={institutions.length}
-        onClick={() => setViewLevel((prev) => prev + 1)}
-      />
-
       {selectedInstitution && <InstitutionDetail families={families} />}
-    </div>
+    </>
   );
 };
 

--- a/src/app/(admin)/admin/organization/page.tsx
+++ b/src/app/(admin)/admin/organization/page.tsx
@@ -93,7 +93,7 @@ const Page = () => {
       </div>
 
       <TableHeader
-        items={INSTITUTION_FAMILY_TABLE_ITEMS}
+        TABLE_COLUMNS={INSTITUTION_FAMILY_TABLE_ITEMS}
         keyPrefix={"inst-f"}
         className="break-keep"
       />

--- a/src/stores/admin/useOrganizationAdminStore.ts
+++ b/src/stores/admin/useOrganizationAdminStore.ts
@@ -1,4 +1,7 @@
-import { Families, OrganizationInfo } from "@/types/admin-organization-dto";
+import {
+  OrganizationFamilies,
+  OrganizationInfo,
+} from "@/types/admin-organization-dto";
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
 import { immer } from "zustand/middleware/immer";
@@ -7,9 +10,9 @@ const ADMIN_STORAGE_KEY = "deardream-organization";
 
 interface OrganizationAdminState {
   organizationInfo: OrganizationInfo;
-  families: Families[];
+  families: OrganizationFamilies[];
   setOrganizationInfo: (organizationInfo: OrganizationInfo) => void;
-  setFamilies: (families: Families[]) => void;
+  setFamilies: (families: OrganizationFamilies[]) => void;
 }
 
 const mockOrg: OrganizationInfo = {
@@ -21,7 +24,7 @@ const mockOrg: OrganizationInfo = {
   phone: "02-123-3456",
   deliveryStatus: "PENDING",
 };
-export const mockFam: Families[] = [
+export const mockFam: OrganizationFamilies[] = [
   {
     familyId: 1,
     archiveId: 1,

--- a/src/stores/admin/useSuperAdminStroe.ts
+++ b/src/stores/admin/useSuperAdminStroe.ts
@@ -1,4 +1,3 @@
-import { DELIVERY_STATUS } from "@/constants/delivery-status";
 import { IndividualsDto, InstitutionsDto } from "@/types/admin-dto";
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
@@ -11,97 +10,17 @@ interface SuperAdminState {
   institutions: InstitutionsDto[];
   setIndividuals: (individuals: IndividualsDto[]) => void;
   setInstitutions: (institutions: InstitutionsDto[]) => void;
+  pivotDate: Date;
+  setPivotDate: (newPivotDate: Date) => void;
 }
-
-const mockIndividuals: IndividualsDto[] = [
-  {
-    name: "김영서",
-    address: "서울특별시 서대문구 이화여대길 52",
-    postalCode: "03760",
-    phone: "010-1234-5678",
-    deliveryStatus: DELIVERY_STATUS.PENDING.value,
-    pdfUrl: "/mock/1.pdf",
-    addressDetail: "신공학관 지하 2층",
-    archiveId: 0,
-  },
-  {
-    name: "피우다",
-    address: "서울특별시 마포구 마포대로 122",
-    postalCode: "04213",
-    phone: "02-6953-0539",
-    deliveryStatus: DELIVERY_STATUS.PENDING.value,
-    pdfUrl: "/mock/1.pdf",
-    addressDetail: "프론트원 6층 ICT COC",
-    archiveId: 1,
-  },
-  {
-    name: "소셜벤처",
-    address: "서울특별시 중구 명동10길 52",
-    postalCode: "04536",
-    phone: "010-1234-5678",
-    deliveryStatus: DELIVERY_STATUS.PENDING.value,
-    pdfUrl: "/mock/1.pdf",
-    addressDetail: "신한익스페이스 지하 1층 신한복지재단",
-    archiveId: 2,
-  },
-];
-
-const mockInstitutions: InstitutionsDto[] = [
-  {
-    name: "피우다요양원",
-    address: "서울특별시 마포구 마포대로 122, 프론트원",
-    postalCode: "04213",
-    phone: "02-6953-0539",
-    deliveryStatus: DELIVERY_STATUS.PENDING.value,
-    pdfUrl: "/mock/1.pdf",
-    code: "YB12",
-    currentMembers: 100,
-    nextMembers: 100,
-    institutionId: 1,
-  },
-  {
-    name: "소셜벤처요양원",
-    address: "서울특별시 마포구 마포대로 122, 프론트원",
-    postalCode: "04213",
-    phone: "02-6953-0539",
-    deliveryStatus: DELIVERY_STATUS.PENDING.value,
-    pdfUrl: "/mock/1.pdf",
-    code: "YB12",
-    currentMembers: 100,
-    nextMembers: 100,
-    institutionId: 2,
-  },
-  {
-    name: "서울희망요양원",
-    address: "서울특별시 마포구 마포대로 122, 프론트원",
-    postalCode: "04213",
-    phone: "02-6953-0539",
-    deliveryStatus: DELIVERY_STATUS.PENDING.value,
-    pdfUrl: "/mock/1.pdf",
-    code: "YB12",
-    currentMembers: 100,
-    nextMembers: 100,
-    institutionId: 3,
-  },
-  {
-    name: "허거덩복지센터",
-    address: "서울특별시 마포구 마포대로 122, 프론트원",
-    postalCode: "04213",
-    phone: "02-6953-0539",
-    deliveryStatus: DELIVERY_STATUS.PENDING.value,
-    pdfUrl: "/mock/1.pdf",
-    code: "YB12",
-    currentMembers: 10,
-    nextMembers: 10,
-    institutionId: 4,
-  },
-];
 
 export const useSuperAdminStore = create<SuperAdminState>()(
   persist(
     immer((set) => ({
-      individuals: mockIndividuals,
-      institutions: mockInstitutions,
+      individuals: [],
+      institutions: [],
+      pivotDate: new Date(),
+      setPivotDate: (newPivotDate) => set({ pivotDate: newPivotDate }),
       setIndividuals: (individuals) => set({ individuals }),
       setInstitutions: (institutions) => set({ institutions }),
     })),

--- a/src/stores/admin/useSuperAdminStroe.ts
+++ b/src/stores/admin/useSuperAdminStroe.ts
@@ -25,8 +25,8 @@ export const useSuperAdminStore = create<SuperAdminState>()(
       updatePivotDate: (value) =>
         set((state) => ({
           pivotDate: new Date(
-            state.pivotDate.getFullYear(),
-            state.pivotDate.getMonth() + value,
+            new Date(state.pivotDate).getFullYear(),
+            new Date(state.pivotDate).getMonth() + value,
             1,
           ),
         })),

--- a/src/stores/admin/useSuperAdminStroe.ts
+++ b/src/stores/admin/useSuperAdminStroe.ts
@@ -11,7 +11,8 @@ interface SuperAdminState {
   setIndividuals: (individuals: IndividualsDto[]) => void;
   setInstitutions: (institutions: InstitutionsDto[]) => void;
   pivotDate: Date;
-  setPivotDate: (newPivotDate: Date) => void;
+  setPivotDate: (newDate: Date | string) => void;
+  updatePivotDate: (value: -1 | 1) => void;
 }
 
 export const useSuperAdminStore = create<SuperAdminState>()(
@@ -20,7 +21,15 @@ export const useSuperAdminStore = create<SuperAdminState>()(
       individuals: [],
       institutions: [],
       pivotDate: new Date(),
-      setPivotDate: (newPivotDate) => set({ pivotDate: newPivotDate }),
+      setPivotDate: (date) => set({ pivotDate: new Date(date) }),
+      updatePivotDate: (value) =>
+        set((state) => ({
+          pivotDate: new Date(
+            state.pivotDate.getFullYear(),
+            state.pivotDate.getMonth() + value,
+            1,
+          ),
+        })),
       setIndividuals: (individuals) => set({ individuals }),
       setInstitutions: (institutions) => set({ institutions }),
     })),

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -8,7 +8,7 @@
 
   /* green btn */
   .button {
-    @apply text-grey-50 text-title-1 flex items-center justify-center gap-1 rounded-sm bg-green-300 px-[0.88rem] py-2;
+    @apply text-grey-50 text-title-1 disabled:text-grey-400 disabled:bg-grey-100 flex items-center justify-center gap-1 rounded-sm bg-green-300 px-[0.88rem] py-2 disabled:cursor-none;
   }
 
   /* modal-dialog */

--- a/src/types/admin-dto.ts
+++ b/src/types/admin-dto.ts
@@ -1,22 +1,24 @@
 export interface AdminCommonDto {
-  name: string;
   address: string;
   postalCode: string;
   phone: string;
-  deliveryStatus: string;
   pdfUrl: string;
+  deliveryStatus: string;
 }
 
 export interface IndividualsDto extends AdminCommonDto {
+  receiverName: string;
   addressDetail: string;
   archiveId: number;
 }
 
 export interface InstitutionsDto extends AdminCommonDto {
-  code: string; // 기관 코드
+  institutionName: string;
+  institutionId: number;
+  institutionCode: string; // 기관 코드
   currentMembers: number; //당월 인원
   nextMembers: number; //익월 인원
-  institutionId: number;
+  pdfUrl: string;
 }
 
 export interface AddInstitutionDto {

--- a/src/types/admin-dto.ts
+++ b/src/types/admin-dto.ts
@@ -13,9 +13,9 @@ export interface IndividualsDto extends AdminCommonDto {
 }
 
 export interface InstitutionsDto extends AdminCommonDto {
-  institutionName: string;
+  name: string;
   institutionId: number;
-  institutionCode: string; // 기관 코드
+  code: string; // 기관 코드
   currentMembers: number; //당월 인원
   nextMembers: number; //익월 인원
   pdfUrl: string;

--- a/src/types/admin-organization-dto.ts
+++ b/src/types/admin-organization-dto.ts
@@ -1,11 +1,24 @@
 export interface Families {
-  familyId: number;
   archiveId: number;
+  familyId: number;
   receiverName: string;
   addressDetail: string;
-  createdAt: string;
   deliveryStatus: string;
+  pdfUrl: string;
+
   phone: string;
+  createdAt: string;
+}
+
+export interface OrganizationFamilies {
+  archiveId: number;
+  familyId: number;
+  receiverName: string;
+  addressDetail: string;
+  deliveryStatus: string;
+
+  phone: string;
+  createdAt: string;
 }
 
 export interface OrganizationInfo {


### PR DESCRIPTION
## Feat: 어드민 페이지 API 연결, 페이지 2

### 이슈 번호 📎

- closed #37 

### 변경사항 🛠

- 어드민 api 5개 (GET2, POST3) 연결
- 상태 변경 모달 구현
- 상태 변경 점검 로직 추후 추가

### 특이사항 📌

- (이 PR에 대한 추가적인 정보나, 리뷰어가 주의깊게 봐야할 점 등을 적어주세요.)
